### PR TITLE
Updated TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 	"description": "An animation library for Roblox",
 	"main": "src/init.lua",
 	"types": "typings/index.d.ts",
-	"files": [ "src", "typings" ],
+	"files": [
+		"src",
+		"typings"
+	],
 	"license": "MIT",
 	"author": "Reselim",
 	"homepage": "https://github.com/Reselim/Flipper",

--- a/typings/BaseMotor.d.ts
+++ b/typings/BaseMotor.d.ts
@@ -1,11 +1,6 @@
 import { Connection } from "./Signal"
 
-export default class BaseMotor<T> {
-	/**
-	 * Creates a new BaseMotor
-	 */
-	constructor()
-
+declare interface BaseMotor<T> {
 	/**
 	 * Connects a function to be called whenever the motor updates
 	 * @param handler
@@ -41,3 +36,5 @@ export default class BaseMotor<T> {
 	 */
 	step(deltaTime: number): boolean
 }
+
+export = BaseMotor;

--- a/typings/BaseMotor.d.ts
+++ b/typings/BaseMotor.d.ts
@@ -1,6 +1,6 @@
 import { Connection } from "./Signal"
 
-export default class BaseMotor {
+export default class BaseMotor<T> {
 	/**
 	 * Creates a new BaseMotor
 	 */
@@ -10,7 +10,7 @@ export default class BaseMotor {
 	 * Connects a function to be called whenever the motor updates
 	 * @param handler
 	 */
-	onStep(handler: (value: unknown) => void): Connection
+	onStep(handler: (value: T) => void): Connection
 	
 	/**
 	 * Connects a function to be called whenever the motor completes

--- a/typings/GroupMotor.d.ts
+++ b/typings/GroupMotor.d.ts
@@ -1,19 +1,26 @@
-export default class GroupMotor {
+import Spring from "./Spring";
+import BaseMotor from "./BaseMotor";
+import Instant from "./Instant";
+
+// Infers the type for setGoal
+type GroupMotorGoals<T> = T extends Array<number> ? Array<Spring | Instant> : T extends object ? {[P in keyof T]: Spring | Instant} : never; 
+
+export default class GroupMotor<T extends Array<number> | {[name: string]: number}> extends BaseMotor<T> {
 	/**
 	 * Creates a new GroupMotor
 	 * @param initialValues Value to set the motor to initially
 	 * @param useImplicitConnections Should this motor manage RenderStepped connections automatically?
 	 */
-	constructor(initialValues: object, useImplicitConnections?: boolean)
+	constructor(initialValues: T, useImplicitConnections?: boolean)
 
 	/**
 	 * TODO
 	 */
-	getValue(): object
+	getValue(): T;
 
 	/**
 	 * TODO
 	 * @param goals 
 	 */
-	setGoal(goals: object): void
+	setGoal(goals: GroupMotorGoals<T>): void;
 }

--- a/typings/GroupMotor.d.ts
+++ b/typings/GroupMotor.d.ts
@@ -1,19 +1,16 @@
-import Spring from "./Spring";
 import BaseMotor from "./BaseMotor";
 import Instant from "./Instant";
+import Spring from "./Spring";
 
 // Infers the type for setGoal
-type GroupMotorGoals<T> = T extends Array<number> ? Array<Spring | Instant> : T extends object ? {[P in keyof T]: Spring | Instant} : never; 
+type GroupMotorGoals<T> = T extends Array<number> ? 
+	Array<Spring | Instant> 
+	: T extends {[name: string]: number} ? 
+	{[P in keyof T]: Spring | Instant}
+	: never; 
 
-export default class GroupMotor<T extends Array<number> | {[name: string]: number}> extends BaseMotor<T> {
-	/**
-	 * Creates a new GroupMotor
-	 * @param initialValues Value to set the motor to initially
-	 * @param useImplicitConnections Should this motor manage RenderStepped connections automatically?
-	 */
-	constructor(initialValues: T, useImplicitConnections?: boolean)
-
-	/**
+declare interface GroupMotor<T> extends BaseMotor<T> {
+		/**
 	 * TODO
 	 */
 	getValue(): T;
@@ -24,3 +21,10 @@ export default class GroupMotor<T extends Array<number> | {[name: string]: numbe
 	 */
 	setGoal(goals: GroupMotorGoals<T>): void;
 }
+
+declare interface GroupMotorConstructor {
+	new<T extends Array<number> | {[name: string]: number}>(initialValues: T, useImplicitConnections?: boolean): GroupMotor<T>;
+}
+
+declare const GroupMotor: GroupMotorConstructor;
+export = GroupMotor;

--- a/typings/Instant.d.ts
+++ b/typings/Instant.d.ts
@@ -3,12 +3,13 @@ interface InstantState {
 	complete: boolean
 }
 
-export default class Instant {
-	/**
-	 * Creates a new Instant goal
-	 * @param targetValue
-	 */
-	constructor(targetValue: number)
-
-	step(state: InstantState, deltaTime: number): InstantState
+declare interface Instant {
+	step(state: InstantState, deltaTime: number): InstantState;
 }
+
+declare interface InstantConstructor {
+	new(targetValue: number): Instant;
+}
+
+declare const Instant: InstantConstructor;
+export = Instant;

--- a/typings/SingleMotor.d.ts
+++ b/typings/SingleMotor.d.ts
@@ -1,14 +1,7 @@
-import Instant from "./Instant";
-import Spring from "./Spring";
+import { Spring, Instant } from ".";
 import BaseMotor from "./BaseMotor"
 
-export default class SingleMotor extends BaseMotor<number> {
-	/**
-	 * Creates a new SingleMotor
-	 * @param initialValue Value to set the motor to initially
-	 * @param useImplicitConnections Should this motor manage RenderStepped connections automatically?
-	 */
-	constructor(initialValue: number, useImplicitConnections?: boolean)
+declare interface SingleMotor extends BaseMotor<number> {
 
 	/**
 	 * TODO
@@ -22,3 +15,15 @@ export default class SingleMotor extends BaseMotor<number> {
 	 */
 	setGoal(goal: Spring | Instant): void;
 }
+
+declare interface SingleMotorConstructor {
+	/**
+	 * Creates a new SingleMotor
+	 * @param initialValue Value to set the motor to initially
+	 * @param useImplicitConnections Should this motor manage RenderStepped connections automatically?
+	 */
+	new(initialValue: number, useImplicitConnections?: boolean): SingleMotor;
+}
+
+declare const SingleMotor: SingleMotorConstructor;
+export = SingleMotor;

--- a/typings/SingleMotor.d.ts
+++ b/typings/SingleMotor.d.ts
@@ -1,6 +1,8 @@
+import Instant from "./Instant";
+import Spring from "./Spring";
 import BaseMotor from "./BaseMotor"
 
-export default class SingleMotor extends BaseMotor {
+export default class SingleMotor extends BaseMotor<number> {
 	/**
 	 * Creates a new SingleMotor
 	 * @param initialValue Value to set the motor to initially
@@ -12,11 +14,11 @@ export default class SingleMotor extends BaseMotor {
 	 * TODO
 	 * @returns The current value of the motor
 	 */
-	getValue(): number
+	getValue(): number;
 
 	/**
 	 * TODO
 	 * @param goal 
 	 */
-	setGoal(goal: any): void
+	setGoal(goal: Spring | Instant): void;
 }

--- a/typings/Spring.d.ts
+++ b/typings/Spring.d.ts
@@ -1,24 +1,21 @@
-import Instant from "./Instant";
-import Spring from "./Spring";
-import BaseMotor from "./BaseMotor"
-
-export default class SingleMotor extends BaseMotor<number> {
-	/**
-	 * Creates a new SingleMotor
-	 * @param initialValue Value to set the motor to initially
-	 * @param useImplicitConnections Should this motor manage RenderStepped connections automatically?
-	 */
-	constructor(initialValue: number, useImplicitConnections?: boolean)
-
-	/**
-	 * TODO
-	 * @returns The current value of the motor
-	 */
-	getValue(): number;
-
-	/**
-	 * TODO
-	 * @param goal 
-	 */
-	setGoal(goal: Spring | Instant): void;
+interface SpringState {
+	complete: boolean,
+	position: number,
+	velocity: number
 }
+
+interface SpringOptions {
+	frequency?: number;
+	dapingRatio?: number;
+}
+
+declare interface Spring {
+	step(state: SpringState, deltaTime: number): SpringState
+}
+
+declare interface SpringConstructor {
+	new(targetValue: number, options?: SpringOptions): Spring;
+}
+
+declare const Spring: SpringConstructor;
+export = Spring;

--- a/typings/Spring.d.ts
+++ b/typings/Spring.d.ts
@@ -1,19 +1,24 @@
-interface SpringState {
-	complete: boolean,
-	position: number,
-	velocity: number
-}
+import Instant from "./Instant";
+import Spring from "./Spring";
+import BaseMotor from "./BaseMotor"
 
-export default class Spring {
+export default class SingleMotor extends BaseMotor<number> {
 	/**
-	 * Creates a new Spring goal
-	 * @param targetValue
-	 * @param options 
+	 * Creates a new SingleMotor
+	 * @param initialValue Value to set the motor to initially
+	 * @param useImplicitConnections Should this motor manage RenderStepped connections automatically?
 	 */
-	constructor(targetValue: number, options?: {
-		frequency?: number,
-		dampingRatio?: number
-	})
-	
-	step(state: SpringState, deltaTime: number): SpringState
+	constructor(initialValue: number, useImplicitConnections?: boolean)
+
+	/**
+	 * TODO
+	 * @returns The current value of the motor
+	 */
+	getValue(): number;
+
+	/**
+	 * TODO
+	 * @param goal 
+	 */
+	setGoal(goal: Spring | Instant): void;
 }


### PR DESCRIPTION
This should bring flipper to be properly supported by roblox-ts, and be more strongly typed than it was.

### Changes
- Interface constructors vs classes - Since `Flipper` is a Lua-based library, have typed it as such. Since TypeScript classes are compiled in a certain way, it's an explicit way of saying it's incompatible with TypeScript classes.

- `export =` vs `export default`. The former is the proper way to export single return Lua modules. `export default` is meant for when the value is exported with the name `default`. 
   ```lua
   -- example:
   local exports = {}
   exports.default = value
   return exports
   ```


- `BaseMotor<T>`
  Strictly interface - This is a base class. I would presume there's no reason for users to create their own motors? Let me know otherwise.
   Generic <T> argument - Determines what `value` in `onStep`'s handler is typed as
- `GroupMotor<T>`
   Generic <T> argument - Since GroupMotor takes an array or object, this is used to determine the resulting type of `setGoal` as well as `getValue()` , and also used to determine `T` in `BaseMotor<T>`.

- `SingleMotor` is non-generic, and extends `BaseMotor<number>`.

I haven't updated any of the JSDocs though, if you want to change those now with the changes feel free to.