### PR TITLE
Added onStart signal

### DIFF
--- a/src/BaseMotor.lua
+++ b/src/BaseMotor.lua
@@ -10,12 +10,17 @@ BaseMotor.__index = BaseMotor
 function BaseMotor.new()
 	return setmetatable({
 		_onStep = Signal.new(),
+		_onStart = Signal.new(),
 		_onComplete = Signal.new()
 	}, BaseMotor)
 end
 
 function BaseMotor:onStep(handler)
 	return self._onStep:connect(handler)
+end
+
+function BaseMotor:onStart(handler)
+	return self._onStart:connect(handler)
 end
 
 function BaseMotor:onComplete(handler)

--- a/src/GroupMotor.lua
+++ b/src/GroupMotor.lua
@@ -75,6 +75,7 @@ end
 
 function GroupMotor:setGoal(goals)
 	self._complete = false
+	self._onStart:fire()
 
 	for key, goal in pairs(goals) do
 		local motor = assert(self._motors[key], ("Unknown motor for key %s"):format(key))

--- a/src/GroupMotor.spec.lua
+++ b/src/GroupMotor.spec.lua
@@ -3,7 +3,7 @@ return function()
 
 	local Instant = require(script.Parent.Instant)
 	local Spring = require(script.Parent.Spring)
-	
+
 	it("should complete when all child motors are complete", function()
 		local motor = GroupMotor.new({
 			A = 1,
@@ -28,6 +28,29 @@ return function()
 		end
 
 		expect(motor._complete).to.equal(true)
+	end)
+
+	it("should start when the goal is set", function()
+		local motor = GroupMotor.new({
+			A = 0
+		}, false)
+
+		local bool = false
+		motor:onStart(function()
+			bool = not bool
+		end)
+
+		motor:setGoal({
+			A = Instant.new(1)
+		})
+
+		expect(bool).to.equal(true)
+
+		motor:setGoal({
+			A = Instant.new(1)
+		})
+
+		expect(bool).to.equal(false)
 	end)
 
 	it("should properly return all values", function()

--- a/src/SingleMotor.lua
+++ b/src/SingleMotor.lua
@@ -53,6 +53,8 @@ function SingleMotor:setGoal(goal)
 	self._state.complete = false
 	self._goal = goal
 
+	self._onStart:fire()
+
 	if self._useImplicitConnections then
 		self:start()
 	end

--- a/src/SingleMotor.spec.lua
+++ b/src/SingleMotor.spec.lua
@@ -14,7 +14,7 @@ return function()
 
 	it("should invoke onComplete listeners when the goal is completed", function()
 		local motor = SingleMotor.new(0, false)
-		
+
 		local didComplete = false
 		motor:onComplete(function()
 			didComplete = true
@@ -24,5 +24,22 @@ return function()
 		motor:step(1/60)
 
 		expect(didComplete).to.equal(true)
+	end)
+
+	it("should start when the goal is set", function()
+		local motor = SingleMotor.new(0, false)
+
+		local bool = false
+		motor:onStart(function()
+			bool = not bool
+		end)
+
+		motor:setGoal(Instant.new(5))
+
+		expect(bool).to.equal(true)
+
+		motor:setGoal(Instant.new(5))
+
+		expect(bool).to.equal(false)
 	end)
 end

--- a/typings/BaseMotor.d.ts
+++ b/typings/BaseMotor.d.ts
@@ -6,7 +6,13 @@ declare interface BaseMotor<T> {
 	 * @param handler
 	 */
 	onStep(handler: (value: T) => void): Connection
-	
+
+	/**
+	 * Connects a function to be called whenever the motor's goal is set
+	 * @param handler
+	 */
+	onStart(handler: () => void): Connection
+
 	/**
 	 * Connects a function to be called whenever the motor completes
 	 * @param handler
@@ -15,7 +21,7 @@ declare interface BaseMotor<T> {
 
 	/**
 	 * Hooks up a connection to RunService.RenderStepped
-	 * 
+	 *
 	 * You shouldn't need to use this.
 	 */
 	start(): void


### PR DESCRIPTION
I've come across an issue recently where I needed to begin something when the motor's goal is set. Using Roact, I was setting the goal of the motor from many different places which is why I find this signal to be useful.
Specifically, I was creating a custom MouseEnter/MouseLeft function due to it not updating while the mouse is still. The motor is being changed multiple times from all over and I know the UI will only be moving when it's set. Maybe this seems a little niche and it's just API bloat, but perhaps there is more use for it elsewhere.