### PR TITLE
make values of goals in setGoal goals argument optional

### DIFF
--- a/typings/GroupMotor.d.ts
+++ b/typings/GroupMotor.d.ts
@@ -7,7 +7,7 @@ import Spring from "./Spring"
 type GroupMotorGoals<T> = T extends Array<number> ? 
 	Array<Spring | Instant>
 	: T extends {[name: string]: number} ?
-	{[P in keyof T]: Spring | Instant}
+	{[P in keyof T]?: Spring | Instant}
 	: never
 
 declare interface GroupMotor<T> extends BaseMotor<T> {


### PR DESCRIPTION
Currently when you provid an object to a GroupMotor's setGoal, you have to define all fields. This just makes it so the fields are optional.
ex a GroupMotor of type `GroupMotor<{ X: number, Y: number }>`
```ts
GroupMotor.setGoal({ X: 10 }) // Errors, You have to define Y, doesn't error with this change.
```