### PR TITLE
Add error message when Spring is passed to motor constructor

### DIFF
--- a/src/GroupMotor.lua
+++ b/src/GroupMotor.lua
@@ -24,6 +24,7 @@ end
 
 function GroupMotor.new(initialValues, useImplicitConnections)
 	assert(initialValues, "Missing argument #1: initialValues")
+	assert(tostring(initialValues) ~= "Spring", "initialValues cannot be a Spring")
 	assert(typeof(initialValues) == "table", "initialValues must be a table!")
 
 	local self = setmetatable(BaseMotor.new(), GroupMotor)

--- a/src/GroupMotor.spec.lua
+++ b/src/GroupMotor.spec.lua
@@ -64,4 +64,12 @@ return function()
 		expect(value.A).to.equal(1)
 		expect(value.B).to.equal(2)
 	end)
+
+	it("should fail when passed a Spring as an initialValue", function()
+		expect(function()
+			GroupMotor.new({
+				InvalidInitialValue = Spring.new(5)
+			})
+		end).to.throw()
+	end)
 end

--- a/src/SingleMotor.lua
+++ b/src/SingleMotor.lua
@@ -5,6 +5,7 @@ SingleMotor.__index = SingleMotor
 
 function SingleMotor.new(initialValue, useImplicitConnections)
 	assert(initialValue, "Missing argument #1: initialValue")
+	assert(tostring(initialValue) ~= "Spring", "initialValue cannot be a Spring")
 	assert(typeof(initialValue) == "number", "initialValue must be a number!")
 
 	local self = setmetatable(BaseMotor.new(), SingleMotor)

--- a/src/Spring.lua
+++ b/src/Spring.lua
@@ -105,4 +105,8 @@ function Spring:step(state, dt)
 	}
 end
 
+function Spring:__tostring()
+	return "Spring"
+end
+
 return Spring


### PR DESCRIPTION
Flipper doesn't support receiving Springs as intial values for SingleMotors or GroupMotors, but for GroupMotors in particular, it's extremely difficult to diagnose this issue since it creates a cascading tree of single motors instead of properly throwing. This PR properly throws with a clear error message when this mistake is made warning the developer not to use Springs in motor constructors.

This change should be backwards compatible since using springs as constructor arguments was never supported and caused weird behavior anyway.