### PR TITLE
Add support to update all motors in groupmotors with a single mutual goal

### DIFF
--- a/src/GroupMotor.lua
+++ b/src/GroupMotor.lua
@@ -84,6 +84,8 @@ end
 		motor:setGoal(Flipper.Spring.new, 0, { frequency = 2, dampingRatio = 1, })
 ]]
 function GroupMotor:setGoal(goals: table | func, target: number?, options: table?)
+	assert(not goals.step, "goals contains disallowed property \"step\". Did you mean to put a table of goals here?")
+
 	self._complete = false
 	self._onStart:fire()
 

--- a/src/GroupMotor.spec.lua
+++ b/src/GroupMotor.spec.lua
@@ -30,6 +30,29 @@ return function()
 		expect(motor._complete).to.equal(true)
 	end)
 
+	it("should complete when all child motors are complete (single goal)", function()
+		local motor = GroupMotor.new({
+			A = 1,
+			B = 2,
+		}, false)
+
+		expect(motor._complete).to.equal(true)
+
+		motor:setGoal(Spring.new, 4, { frequency = 7.5, dampingRatio = 1 })
+
+		expect(motor._complete).to.equal(false)
+
+		motor:step(1/60)
+
+		expect(motor._complete).to.equal(false)
+
+		for _ = 1, 0.5 * 60 do
+			motor:step(1/60)
+		end
+
+		expect(motor._complete).to.equal(true)
+	end)
+
 	it("should start when the goal is set", function()
 		local motor = GroupMotor.new({
 			A = 0,


### PR DESCRIPTION
Adds option to use a single goal to update all motors in a groupmotor. This is useful when you want to add a mutual goal for all motors without having to type out each one.
```lua
motor:setGoal(Flipper.Spring.new, 0, { frequency = 2, dampingRatio = 1, })
```
An alternative implementation would be to take in the 3 args in a single table so it is consistent with the parameters for a table of goals. That would require this syntax though -
```lua
motor:setGoal({ Flipper.Spring.new, 0, { frequency = 2, dampingRatio = 1, } })
```