### PR TITLE
updated SingleMotor.lua to have assert

### DIFF
--- a/src/SingleMotor.lua
+++ b/src/SingleMotor.lua
@@ -50,6 +50,9 @@ function SingleMotor:getValue()
 end
 
 function SingleMotor:setGoal(goal)
+	assert(goal.frequency ~= nil, "incorrectly formatted goal table, must have frequency key")
+	assert(goal.dampingRatio ~= nil, "incorrectly formatted goal table, must have frequency key")
+	
 	self._state.complete = false
 	self._goal = goal
 


### PR DESCRIPTION
Its a simple change but overall helps in case you forget to format the options table which I have done on a few occasions. It was difficult to figure out what the issue was since the  traceback leads to the signal class so I thought a couple asserts in the setGoal function would help debugging in the future.