### PR TITLE
Update Spring.lua With Asserts

### DIFF
--- a/src/Spring.lua
+++ b/src/Spring.lua
@@ -7,6 +7,12 @@ local Spring = {}
 Spring.__index = Spring
 
 function Spring.new(targetValue, options)
+	
+	if options ~= nil then
+		assert(options.frequency ~= nil, "Incorrrectly formatted options table, must have a frequency key")
+		assert(options.dampingRatio ~= nil, "Incorrrectly formatted options table, must have a dammpingRatio key")
+	end
+
 	assert(targetValue, "Missing argument #1: targetValue")
 	options = options or {}
 


### PR DESCRIPTION
I added asserts into the spring.new function to make sure the table they inputted has the correct frequency and dampingRatio keys if they have an options table. before the change the traceback would lead to the signal module which doesnt say much about the error but now would say directly what options you are missing. Its a small change but overall can help with debugging when passing props down that have frequency in the name which can be confused with the frequency key itself. This also applies to damping Ratio.